### PR TITLE
Fix: Cannot read property 'manifest' of undefined

### DIFF
--- a/hooks/lib/android/manifestWriter.js
+++ b/hooks/lib/android/manifestWriter.js
@@ -18,7 +18,7 @@ module.exports = {
  * @param {Object} pluginPreferences - plugin preferences as JSON object; already parsed
  */
 function writePreferences(cordovaContext, pluginPreferences) {
-  var pathToManifest = path.join(cordovaContext.opts.projectRoot, 'platforms', 'android', 'AndroidManifest.xml');
+  var pathToManifest = path.join(cordovaContext.opts.projectRoot, 'platforms', 'android', 'app', 'src', 'main', 'AndroidManifest.xml');
   var manifestSource = xmlHelper.readXmlAsJson(pathToManifest);
   var cleanManifest;
   var updatedManifest;


### PR DESCRIPTION
Fixed hard coded path as proposed here:
https://stackoverflow.com/questions/52961516/cannot-read-property-manifest-of-undefined-for-firebase-dynamic-link